### PR TITLE
fix when Open Link in New Tab

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -281,7 +281,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, change, _tab) {
       console.log('[notice] redirecting to: ' + newUrl);
       if (isNewTab == false) {
         lastTabId = tabId;
-        chrome.tabs.update({url: newUrl});
+        chrome.tabs.update(tabId, {url: newUrl});
       } else {
         chrome.tabs.create({url: newUrl}, function (_tab) {
           notify();


### PR DESCRIPTION
Hello,
This is probably a fix for this issue https://github.com/URLAutoRedirector/URLAutoRedirector/issues/86
When you want "Redirect in current tab" and when updating a link which had been open in a new tab, it should now update that new tab instead of the current tab you are in.
Tested locally and worked.

Let me know if it is not fixing the issue properly.

Thanks